### PR TITLE
Add asymmetric structure-preserving matching

### DIFF
--- a/src/main/java/it/unitn/disi/smatch/filters/AsymmetricSPSMMappingFilter.java
+++ b/src/main/java/it/unitn/disi/smatch/filters/AsymmetricSPSMMappingFilter.java
@@ -1,0 +1,63 @@
+package it.unitn.disi.smatch.filters;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import it.unitn.disi.smatch.data.mappings.IContextMapping;
+import it.unitn.disi.smatch.data.mappings.IMappingFactory;
+import it.unitn.disi.smatch.data.trees.INode;
+import it.unitn.disi.smatch.matchers.structure.tree.spsm.ted.TreeEditDistance;
+import it.unitn.disi.smatch.matchers.structure.tree.spsm.ted.utils.impl.MatchedTreeNodeComparator;
+import it.unitn.disi.smatch.matchers.structure.tree.spsm.ted.utils.impl.WorstCaseDistanceConversion;
+
+
+/**
+ * This is a modified version of SPSM that treats the two trees asymmetrically:
+ * the source tree is considered to be a query schema while the target tree
+ * is a reference schema. The mapping score is computed based on the extent
+ * the latter covers the former. In other words, it is not dependent on the size
+ * of the reference schema tree.
+ *
+ * @author Gabor BELLA, gabor.bella@unitn.it
+ * @since 2.0.0
+ */
+public class AsymmetricSPSMMappingFilter extends SPSMMappingFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(AsymmetricSPSMMappingFilter.class);
+
+    public AsymmetricSPSMMappingFilter(IMappingFactory mappingFactory) {
+        super(mappingFactory);
+    }
+
+    public AsymmetricSPSMMappingFilter(IMappingFactory mappingFactory, IContextMapping<INode> mapping) {
+        super(mappingFactory, mapping);
+    }
+
+    /**
+     * Computes the similarity score in an asymmetrical manner that only depends
+     * on the size of the source (query) tree.
+     * Insert weight is set to 0 for asymmetric mapping (do not count 
+     * in the distance the nodes that are present in the reference tree 
+     * but are absent from the query tree (and thus need to be inserted).
+     * 
+     * @param mapping mapping
+     * @return similarity score
+     */
+    @Override
+    protected double computeSimilarity(IContextMapping<INode> mapping) {
+        MatchedTreeNodeComparator mntc = new MatchedTreeNodeComparator(mapping);
+        TreeEditDistance tde = new TreeEditDistance(mapping.getSourceContext(), 
+                                    mapping.getTargetContext(), mntc, 
+                                    new WorstCaseDistanceConversion(),
+                                    TreeEditDistance.DEFAULT_PATH_LENGTH_LIMIT,
+                                    0d,
+                                    TreeEditDistance.DEFAULT_WEIGHT_DELETE,
+                                    TreeEditDistance.DEFAULT_WEIGHT_SUBSTITUTE);
+
+        tde.calculate();
+        double ed = tde.getTreeEditDistance();
+
+        return 1 - (ed / mapping.getSourceContext().nodesCount());
+    }
+
+}

--- a/src/main/java/it/unitn/disi/smatch/filters/SPSMMappingFilter.java
+++ b/src/main/java/it/unitn/disi/smatch/filters/SPSMMappingFilter.java
@@ -43,7 +43,7 @@ import java.util.List;
  */
 public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAsyncMappingFilter {
 
-    private static Logger log = LoggerFactory.getLogger(SPSMMappingFilter.class);
+    private static final Logger log = LoggerFactory.getLogger(SPSMMappingFilter.class);
 
     public SPSMMappingFilter(IMappingFactory mappingFactory) {
         super(mappingFactory);

--- a/src/main/java/it/unitn/disi/smatch/filters/SPSMMappingFilter.java
+++ b/src/main/java/it/unitn/disi/smatch/filters/SPSMMappingFilter.java
@@ -43,7 +43,7 @@ import java.util.List;
  */
 public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAsyncMappingFilter {
 
-    private static final Logger log = LoggerFactory.getLogger(SPSMMappingFilter.class);
+    private static Logger log = LoggerFactory.getLogger(SPSMMappingFilter.class);
 
     public SPSMMappingFilter(IMappingFactory mappingFactory) {
         super(mappingFactory);
@@ -109,7 +109,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @param mapping mapping
      * @return similarity score
      */
-    private double computeSimilarity(IContextMapping<INode> mapping) {
+    protected double computeSimilarity(IContextMapping<INode> mapping) {
         MatchedTreeNodeComparator mntc = new MatchedTreeNodeComparator(mapping);
         TreeEditDistance tde = new TreeEditDistance(mapping.getSourceContext(), mapping.getTargetContext(), mntc, new WorstCaseDistanceConversion());
 
@@ -129,7 +129,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @param sourceIndex      list used for reordering of siblings
      * @param targetIndex      list used for reordering of siblings
      */
-    private void filterMappingsOfChildren(INode sourceParent, INode targetParent, char semanticRelation,
+    protected void filterMappingsOfChildren(INode sourceParent, INode targetParent, char semanticRelation,
                                           List<Integer> sourceIndex, List<Integer> targetIndex,
                                           IContextMapping<INode> mapping,
                                           IContextMapping<INode> spsmMapping) {
@@ -164,7 +164,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @param targetIndex      list used for reordering of siblings
      * @param mapping          original mapping
      */
-    private void filterMappingsOfSiblingsByRelation(List<INode> source, List<INode> target, char semanticRelation,
+    protected void filterMappingsOfSiblingsByRelation(List<INode> source, List<INode> target, char semanticRelation,
                                                     List<Integer> sourceIndex, List<Integer> targetIndex,
                                                     IContextMapping<INode> mapping,
                                                     IContextMapping<INode> spsmMapping) {
@@ -228,7 +228,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @param source      index of the source element to be swapped.
      * @param target      index of the target element to be swapped.
      */
-    private void swapINodes(List<INode> listOfNodes, int source, int target) {
+    protected void swapINodes(List<INode> listOfNodes, int source, int target) {
         INode aux = listOfNodes.get(source);
         listOfNodes.set(source, listOfNodes.get(target));
         listOfNodes.set(target, aux);
@@ -246,7 +246,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @param targetIndex list used for reordering of siblings
      * @return the index of the related element in target, or -1 if there is no relate element.
      */
-    private int getRelatedIndex(List<INode> source, List<INode> target, char relation,
+    protected int getRelatedIndex(List<INode> source, List<INode> target, char relation,
                                 List<Integer> sourceIndex, List<Integer> targetIndex,
                                 IContextMapping<INode> mapping,
                                 IContextMapping<INode> spsmMapping) {
@@ -279,7 +279,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @param array array list of integers.
      * @param index index of the element to be incremented.
      */
-    private void inc(List<Integer> array, int index) {
+    protected void inc(List<Integer> array, int index) {
         array.set(index, array.get(index) + 1);
     }
 
@@ -292,7 +292,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @param defaultMapping original mapping
      * @return true if the relation holds between source and target, false otherwise.
      */
-    private boolean isRelated(final INode source, final INode target, final char relation, IContextMapping<INode> defaultMapping) {
+    protected boolean isRelated(final INode source, final INode target, final char relation, IContextMapping<INode> defaultMapping) {
         return relation == defaultMapping.getRelation(source, target);
     }
 
@@ -303,7 +303,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @param source source node
      * @param target target node
      */
-    private void setStrongestMapping(INode source, INode target,
+    protected void setStrongestMapping(INode source, INode target,
                                      IContextMapping<INode> mapping,
                                      IContextMapping<INode> spsmMapping
     ) {
@@ -340,7 +340,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      *
      * @param source INode to look for the strongest relation.
      */
-    private void computeStrongestMappingForSource(INode source,
+    protected void computeStrongestMappingForSource(INode source,
                                                   IContextMapping<INode> mapping,
                                                   IContextMapping<INode> spsmMapping
     ) {
@@ -416,7 +416,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @param source    the node for which more than one strongest relation is found
      * @param strongest the list of the strongest relations.
      */
-    private void resolveStrongestMappingConflicts(INode source,
+    protected void resolveStrongestMappingConflicts(INode source,
                                                   List<IMappingElement<INode>> strongest,
                                                   IContextMapping<INode> mapping,
                                                   IContextMapping<INode> spsmMapping
@@ -464,7 +464,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      *
      * @param e the strongest mapping element.
      */
-    private void deleteRemainingRelationsFromMatrix(IMappingElement<INode> e,
+    protected void deleteRemainingRelationsFromMatrix(IMappingElement<INode> e,
                                                     IContextMapping<INode> mapping) {
         //deletes all the relations in the column
         for (Iterator<INode> sourceNodes = mapping.getSourceContext().nodeIterator(); sourceNodes.hasNext(); ) {
@@ -492,7 +492,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @param target target node.
      * @return true if they are the same structure, false otherwise.
      */
-    private boolean isSameStructure(INode source, INode target) {
+    protected boolean isSameStructure(INode source, INode target) {
         boolean result = false;
         if (null != source && null != target) {
             if (source.getChildren() != null && target.getChildren() != null) {
@@ -519,7 +519,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @param target target node
      * @return true if exists stronger relation in the same column, false otherwise.
      */
-    private boolean existsStrongerInColumn(INode source, INode target,
+    protected boolean existsStrongerInColumn(INode source, INode target,
                                            IContextMapping<INode> mapping) {
         boolean result = false;
 
@@ -547,7 +547,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @param target target relation.
      * @return true if source is more precedent than target, false otherwise.
      */
-    private boolean isPrecedent(char source, char target) {
+    protected boolean isPrecedent(char source, char target) {
         return comparePrecedence(source, target) == 1;
     }
 
@@ -564,7 +564,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * 0 if sourceRelation is equally precedent than targetRelation,
      * 1 if sourceRelation  is more precedent than targetRelation.
      */
-    private int comparePrecedence(char sourceRelation, char targetRelation) {
+    protected int comparePrecedence(char sourceRelation, char targetRelation) {
         int result;
 
         int sourcePrecedence = getPrecedenceNumber(sourceRelation);
@@ -593,7 +593,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @return the order of precedence for the given relation, Integer.MAX_VALUE if the relation
      * is not recognized.
      */
-    private int getPrecedenceNumber(char semanticRelation) {
+    protected int getPrecedenceNumber(char semanticRelation) {
 
         //initializes the precedence number to the least precedent
         int precedence = Integer.MAX_VALUE;


### PR DESCRIPTION

- Adds `AsymmetricSPSMMappingFilter`, a modified version of SPSM that treats the two trees asymmetrically
- Turns `SPSMMappingFilter`  private methods into protected to ease extension from `AsymmetricSPSMMappingFilter`
- based on commit https://github.com/gbella/s-match-spsm/commit/11aaf06ba202bdc6599de0f172fe906059970e7d
  by Gabor Bella