### PR TITLE
Compute unordered TED

### DIFF
--- a/src/main/java/it/unitn/disi/smatch/filters/SPSMMappingFilter.java
+++ b/src/main/java/it/unitn/disi/smatch/filters/SPSMMappingFilter.java
@@ -153,11 +153,11 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      *
      * @param sourceParent     Source node.
      * @param targetParent     Target node.
-     * @param rscParent        Node of the reordered source context.
-     * @param rtcParent        Node of the reordered target context.
+     * @param reorderedSourceParent        Node of the reordered source context.
+     * @param reorderedTargetParent        Node of the reordered target context.
      * @param sourceIndex      list used for reordering of siblings
      * @param targetIndex      list used for reordering of siblings
-     * @param mapping          the original SMATCH mappings
+     * @param mapping          the original S-Match mappings
      *                         to the reordered trees
      * @param unorderedMapping a copy of the original mappings used with
      *                         the reordered trees
@@ -165,7 +165,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @param unorderedSpsmMapping  SPSM-filtered unordered mappings are collected here
      */
     protected void filterMappingsOfChildren(INode sourceParent, INode targetParent, 
-                                          INode rscParent, INode rtcParent,
+                                          INode reorderedSourceParent, INode reorderedTargetParent,
                                           List<Integer> sourceIndex, List<Integer> targetIndex,
                                           IContextMapping<INode> mapping,
                                           IContextMapping<INode> unorderedMapping,
@@ -180,7 +180,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
         if (sourceChildren.size() >= 1 && targetChildren.size() >= 1) {
             //sorts the siblings first with the strongest relation, and then with the others
             filterMappingsOfSiblings(sourceChildren, targetChildren,
-                    rscParent.getChildren(), rtcParent.getChildren(),
+                    reorderedSourceParent.getChildren(), reorderedTargetParent.getChildren(),
                     sourceIndex, targetIndex, mapping, unorderedMapping, 
                     spsmMapping, unorderedSpsmMapping);
         }
@@ -189,10 +189,10 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
         targetIndex.remove(targetParent.ancestorCount());
     }
 
-    protected Map<INode,INode> copyTree(INode from, INode to) {
+    protected Map<INode, INode> copyTree(INode from, INode to) {
         // Copy all source and all target children into the reordered source (rsc)
         // and reordered target (rtc) contexts (trees), respectively
-        Map<INode,INode> copyMap = new HashMap<>();
+        Map<INode, INode> copyMap = new HashMap<>();
         copyNode(from, to);
         copyMap.put(from, to);
         
@@ -223,8 +223,8 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      *
      * @param source           Source list of siblings.
      * @param target           Target list of siblings.
-     * @param rscList          List of source siblings to be reordered.
-     * @param rtcList          List of target siblings to be reordered.
+     * @param reorderedSource          List of source siblings to be reordered.
+     * @param reorderedTarget          List of target siblings to be reordered.
      * @param sourceIndex      list used for reordering of siblings
      * @param targetIndex      list used for reordering of siblings
      * @param mapping          original mapping
@@ -234,8 +234,8 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @param unorderedSpsmMapping  SPSM-filtered unordered mappings are collected here
      */
     protected void filterMappingsOfSiblings(List<INode> source, List<INode> target, 
-                                            List<INode> rscList,
-                                            List<INode> rtcList,
+                                            List<INode> reorderedSource,
+                                            List<INode> reorderedTarget,
                                             List<Integer> sourceIndex, List<Integer> targetIndex,
                                             IContextMapping<INode> mapping,
                                             IContextMapping<INode> unorderedMapping,
@@ -261,8 +261,8 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
                             target.get(targetIndex.get(targetDepth)),
                             mapping, spsmMapping);
                     
-                    setStrongestMapping(rscList.get(sourceIndex.get(sourceDepth)),
-                            rtcList.get(targetIndex.get(targetDepth)),
+                    setStrongestMapping(reorderedSource.get(sourceIndex.get(sourceDepth)),
+                            reorderedTarget.get(targetIndex.get(targetDepth)),
                             unorderedMapping, unorderedSpsmMapping);
                     
                     // Sort the children of the matched node
@@ -272,8 +272,8 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
                     // but it ignores a lot of mappings.
                     filterMappingsOfChildren(source.get(sourceIndex.get(sourceDepth)),
                             target.get(targetIndex.get(targetDepth)), 
-                            rscList.get(sourceIndex.get(sourceDepth)),
-                            rtcList.get(targetIndex.get(targetDepth)),
+                            reorderedSource.get(sourceIndex.get(sourceDepth)),
+                            reorderedTarget.get(targetIndex.get(targetDepth)),
                             sourceIndex, targetIndex, 
                             mapping, unorderedMapping,
                             spsmMapping, unorderedSpsmMapping);
@@ -284,21 +284,21 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
                 } else {
                     //look for the next related node in the target
                     int relatedIndex = getRelatedIndex(source, target, 
-                            rscList, rtcList, semanticRelation,
+                            reorderedSource, reorderedTarget, semanticRelation,
                             sourceIndex, targetIndex, mapping, unorderedMapping, 
                             spsmMapping, unorderedSpsmMapping);
                     if (relatedIndex > sourceIndex.get(sourceDepth)) {
                         //there is a related node, but further between the siblings
                         //they should be swapped
                         swapINodes(target, targetIndex.get(targetDepth), relatedIndex);
-                        swapUnmodifiableINodes(rtcList, targetIndex.get(targetDepth), relatedIndex);
+                        swapUnmodifiableINodes(reorderedTarget, targetIndex.get(targetDepth), relatedIndex);
 
                         //filter the mappings of the children of the matched node
                         // TODO: the same assumption is made here as above
                         filterMappingsOfChildren(source.get(sourceIndex.get(sourceDepth)),
                                 target.get(targetIndex.get(targetDepth)),
-                                rscList.get(targetIndex.get(targetDepth)),
-                                rtcList.get(targetIndex.get(targetDepth)),
+                                reorderedSource.get(targetIndex.get(targetDepth)),
+                                reorderedTarget.get(targetIndex.get(targetDepth)),
                                 sourceIndex, targetIndex, 
                                 mapping, unorderedMapping,
                                 spsmMapping, unorderedSpsmMapping);
@@ -311,7 +311,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
                         //there is no related item among the remaining siblings
                         //swap this element of source with the last, and decrement the sourceSize
                         swapINodes(source, sourceIndex.get(sourceDepth), (sourceSize - 1));
-                        swapUnmodifiableINodes(rscList, sourceIndex.get(sourceDepth), (sourceSize - 1));
+                        swapUnmodifiableINodes(reorderedSource, sourceIndex.get(sourceDepth), (sourceSize - 1));
                         // TODO: here the choice is made to filter out any mappings
                         // of the children of this node. This means that this SPSM
                         // implementation adds a constraint on parents needing
@@ -324,7 +324,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
                         // B
                         //    A
                         //       C
-                        // then, even though SMATCH returns equivalence for the
+                        // then, even though S-Match returns equivalence for the
                         // second and third levels, SPSM eliminates these matches
                         // because A and B do not match on the root level.
                         // It should be reviewed whether this behaviour is intended.
@@ -361,7 +361,6 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @since 2.0.0
      */
     protected void swapUnmodifiableINodes(List<INode> listOfNodes, int source, int target) {
-
         int lowerIndex;
         int higherIndex;
         
@@ -388,8 +387,8 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      *
      * @param source      source list of siblings
      * @param target      target list of siblings
-     * @param rscList     source list of reordered siblings
-     * @param rtcList     target list of reordered siblings
+     * @param reorderedSource     source list of reordered siblings
+     * @param reorderedTarget     target list of reordered siblings
      * @param relation    relation
      * @param sourceIndex list used for reordering of siblings
      * @param targetIndex list used for reordering of siblings
@@ -401,7 +400,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * @return the index of the related element in target, or -1 if there is no relate element.
      */
     protected int getRelatedIndex(List<INode> source, List<INode> target, 
-                                List<INode> rscList, List<INode> rtcList,
+                                List<INode> reorderedSource, List<INode> reorderedTarget,
                                 char relation,
                                 List<Integer> sourceIndex, List<Integer> targetIndex,
                                 IContextMapping<INode> mapping,
@@ -414,12 +413,12 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
         int returnIndex = -1;
 
         INode sourceNode = source.get(srcIndex);
-        INode rsNode = rscList.get(srcIndex);
+        INode rsNode = reorderedSource.get(srcIndex);
 
         //find the first one who is related in the same level
         for (int i = tgtIndex + 1; i < target.size(); i++) {
             INode targetNode = target.get(i);
-            INode rtNode = rtcList.get(i);
+            INode rtNode = reorderedTarget.get(i);
             if (isRelated(sourceNode, targetNode, relation, mapping)) {
                 setStrongestMapping(sourceNode, targetNode, mapping, spsmMapping);
                 setStrongestMapping(rsNode, rtNode, unorderedMapping, unorderedSpsmMapping);
@@ -431,7 +430,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
         //there was no correspondence between siblings in source and target lists
         //try to clean the mapping elements
         computeStrongestMappingForSource(source.get(srcIndex), mapping, spsmMapping);
-        computeStrongestMappingForSource(rscList.get(srcIndex), unorderedMapping, 
+        computeStrongestMappingForSource(reorderedSource.get(srcIndex), unorderedMapping, 
                 unorderedSpsmMapping);
 
         return returnIndex;

--- a/src/main/java/it/unitn/disi/smatch/filters/SPSMMappingFilter.java
+++ b/src/main/java/it/unitn/disi/smatch/filters/SPSMMappingFilter.java
@@ -180,7 +180,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
         if (sourceChildren.size() >= 1 && targetChildren.size() >= 1) {
             //sorts the siblings first with the strongest relation, and then with the others
             filterMappingsOfSiblings(sourceChildren, targetChildren,
-                    rscParent.getModifiableChildren(), rtcParent.getModifiableChildren(),
+                    rscParent.getChildren(), rtcParent.getChildren(),
                     sourceIndex, targetIndex, mapping, unorderedMapping, 
                     spsmMapping, unorderedSpsmMapping);
         }
@@ -291,7 +291,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
                         //there is a related node, but further between the siblings
                         //they should be swapped
                         swapINodes(target, targetIndex.get(targetDepth), relatedIndex);
-                        swapINodes(rtcList, targetIndex.get(targetDepth), relatedIndex);
+                        swapUnmodifiableINodes(rtcList, targetIndex.get(targetDepth), relatedIndex);
 
                         //filter the mappings of the children of the matched node
                         // TODO: the same assumption is made here as above
@@ -311,7 +311,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
                         //there is no related item among the remaining siblings
                         //swap this element of source with the last, and decrement the sourceSize
                         swapINodes(source, sourceIndex.get(sourceDepth), (sourceSize - 1));
-                        swapINodes(rscList, sourceIndex.get(sourceDepth), (sourceSize - 1));
+                        swapUnmodifiableINodes(rscList, sourceIndex.get(sourceDepth), (sourceSize - 1));
                         // TODO: here the choice is made to filter out any mappings
                         // of the children of this node. This means that this SPSM
                         // implementation adds a constraint on parents needing
@@ -350,6 +350,38 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
     }
 
 
+    /**
+     * Swaps the INodes in listOfNodes in the positions source and target,
+     * where listOfNodes is an unmodifiableList.
+     *
+     * @param listOfNodes List of INodes of which the elements should be swapped.
+     * @param source      index of the source child to be swapped.
+     * @param target      index of the target child to be swapped.
+     *
+     * @since 2.0.0
+     */
+    protected void swapUnmodifiableINodes(List<INode> listOfNodes, int source, int target) {
+
+        int lowerIndex;
+        int higherIndex;
+        
+        INode parentNode = listOfNodes.get(0).getParent();
+        if (source < target) {
+            lowerIndex = source;
+            higherIndex = target;
+        } else {
+            lowerIndex = target;
+            higherIndex = source;
+        }
+        INode lowerNode = parentNode.getChildAt(lowerIndex);
+        INode higherNode = parentNode.getChildAt(higherIndex);
+        parentNode.removeChild(higherNode);
+        parentNode.removeChild(lowerNode);
+        parentNode.addChild(lowerIndex, higherNode);
+        parentNode.addChild(higherIndex, lowerNode);
+    }
+    
+    
     /**
      * Looks for the related index for the source list at the position sourceIndex
      * in the target list beginning at the targetIndex position for the defined relation.

--- a/src/main/java/it/unitn/disi/smatch/filters/SPSMMappingFilter.java
+++ b/src/main/java/it/unitn/disi/smatch/filters/SPSMMappingFilter.java
@@ -5,6 +5,7 @@ import it.unitn.disi.smatch.data.mappings.IContextMapping;
 import it.unitn.disi.smatch.data.mappings.IMappingElement;
 import it.unitn.disi.smatch.data.mappings.IMappingFactory;
 import it.unitn.disi.smatch.data.mappings.MappingElement;
+import it.unitn.disi.smatch.data.trees.Context;
 import it.unitn.disi.smatch.data.trees.IContext;
 import it.unitn.disi.smatch.data.trees.INode;
 import it.unitn.disi.smatch.matchers.structure.tree.spsm.ted.TreeEditDistance;
@@ -14,8 +15,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -43,7 +46,7 @@ import java.util.List;
  */
 public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAsyncMappingFilter {
 
-    private static Logger log = LoggerFactory.getLogger(SPSMMappingFilter.class);
+    private static final Logger log = LoggerFactory.getLogger(SPSMMappingFilter.class);
 
     public SPSMMappingFilter(IMappingFactory mappingFactory) {
         super(mappingFactory);
@@ -63,31 +66,56 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
 
             IContext sourceContext = mapping.getSourceContext();
             IContext targetContext = mapping.getTargetContext();
+            IContext reorderedSourceContext = new Context();
+            IContext reorderedTargetContext = new Context();
+            Map<INode,INode> copyMap = new HashMap<>();
+            copyMap.putAll(copyTree(sourceContext.getRoot(), reorderedSourceContext.createRoot()));
+            copyMap.putAll(copyTree(targetContext.getRoot(), reorderedTargetContext.createRoot()));
 
             //used for reordering of siblings
             List<Integer> sourceIndex = new ArrayList<>();
             List<Integer> targetIndex = new ArrayList<>();
 
-            //the mapping to be returned by the filter
-            IContextMapping<INode> spsmMapping = mappingFactory.getContextMappingInstance(sourceContext, targetContext);
+            // the ordered SPSM mapping produced by the filter
+            IContextMapping<INode> spsmMapping = 
+                mappingFactory.getContextMappingInstance(sourceContext, targetContext);
+            // the unordered SPSM mapping produced and returned by the filter
+            IContextMapping<INode> unorderedSpsmMapping =
+                mappingFactory.getContextMappingInstance(reorderedSourceContext, reorderedTargetContext);
+            // the mapping corresponding to the reordered source and target
+            IContextMapping<INode> unorderedMapping = 
+                mappingFactory.getContextMappingInstance(reorderedSourceContext, reorderedTargetContext);
 
-            spsmMapping.setSimilarity(computeSimilarity(mapping));
-            log.info("Similarity: " + spsmMapping.getSimilarity());
+            for (IMappingElement me : mapping) {
+                // copy the corresponding mapping elements into unorderedMapping
+                unorderedMapping.add(new MappingElement<>(copyMap.get((INode)(me.getSource())), 
+                                                              copyMap.get((INode)(me.getTarget())),
+                                                              me.getRelation()));
+            }
 
             if (isRelated(sourceContext.getRoot(), targetContext.getRoot(), IMappingElement.EQUIVALENCE, mapping) ||
                     isRelated(sourceContext.getRoot(), targetContext.getRoot(), IMappingElement.LESS_GENERAL, mapping) ||
                     isRelated(sourceContext.getRoot(), targetContext.getRoot(), IMappingElement.MORE_GENERAL, mapping)) {
 
-                setStrongestMapping(sourceContext.getRoot(), targetContext.getRoot(), mapping, spsmMapping);
-                filterMappingsOfChildren(sourceContext.getRoot(), targetContext.getRoot(), IMappingElement.EQUIVALENCE,
-                        sourceIndex, targetIndex, mapping, spsmMapping);
-                filterMappingsOfChildren(sourceContext.getRoot(), targetContext.getRoot(), IMappingElement.MORE_GENERAL,
-                        sourceIndex, targetIndex, mapping, spsmMapping);
-                filterMappingsOfChildren(sourceContext.getRoot(), targetContext.getRoot(), IMappingElement.LESS_GENERAL,
-                        sourceIndex, targetIndex, mapping, spsmMapping);
+                setStrongestMapping(sourceContext.getRoot(), targetContext.getRoot(), 
+                        mapping, spsmMapping);
+                setStrongestMapping(reorderedSourceContext.getRoot(), reorderedTargetContext.getRoot(), 
+                        unorderedMapping, unorderedSpsmMapping);
+
+                filterMappingsOfChildren(sourceContext.getRoot(), targetContext.getRoot(), 
+                        reorderedSourceContext.getRoot(),
+                        reorderedTargetContext.getRoot(),/*, IMappingElement.EQUIVALENCE*/
+                        sourceIndex, targetIndex, 
+                        mapping, unorderedMapping,
+                        spsmMapping, unorderedSpsmMapping);
             }
 
-            return spsmMapping;
+            unorderedMapping.setSimilarity(computeSimilarity(unorderedSpsmMapping));
+            double orderedSimilarity = computeSimilarity(spsmMapping);
+            log.info("Similarity: " + unorderedMapping.getSimilarity());
+            log.info("Ordered similarity: " + orderedSimilarity);
+
+            return unorderedSpsmMapping;
         }
 
         return mapping;
@@ -125,31 +153,67 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      *
      * @param sourceParent     Source node.
      * @param targetParent     Target node.
-     * @param semanticRelation the relation to use for comparison.
+     * @param rscParent        Node of the reordered source context.
+     * @param rtcParent        Node of the reordered target context.
      * @param sourceIndex      list used for reordering of siblings
      * @param targetIndex      list used for reordering of siblings
+     * @param mapping          the original SMATCH mappings
+     *                         to the reordered trees
+     * @param unorderedMapping a copy of the original mappings used with
+     *                         the reordered trees
+     * @param spsmMapping      SPSM-filtered ordered mappings are collected here
+     * @param unorderedSpsmMapping  SPSM-filtered unordered mappings are collected here
      */
-    protected void filterMappingsOfChildren(INode sourceParent, INode targetParent, char semanticRelation,
+    protected void filterMappingsOfChildren(INode sourceParent, INode targetParent, 
+                                          INode rscParent, INode rtcParent,
                                           List<Integer> sourceIndex, List<Integer> targetIndex,
                                           IContextMapping<INode> mapping,
-                                          IContextMapping<INode> spsmMapping) {
-        List<INode> source = new ArrayList<>(sourceParent.getChildren());
-        List<INode> target = new ArrayList<>(targetParent.getChildren());
-
+                                          IContextMapping<INode> unorderedMapping,
+                                          IContextMapping<INode> spsmMapping,
+                                          IContextMapping<INode> unorderedSpsmMapping) {
+        List<INode> sourceChildren = new ArrayList<>(sourceParent.getChildren());
+        List<INode> targetChildren = new ArrayList<>(targetParent.getChildren());
+        
         sourceIndex.add(sourceParent.ancestorCount(), 0);
         targetIndex.add(targetParent.ancestorCount(), 0);
 
-        if (source.size() >= 1 && target.size() >= 1) {
+        if (sourceChildren.size() >= 1 && targetChildren.size() >= 1) {
             //sorts the siblings first with the strongest relation, and then with the others
-            filterMappingsOfSiblingsByRelation(source, target, semanticRelation,
-                    sourceIndex, targetIndex,
-                    mapping, spsmMapping);
+            filterMappingsOfSiblings(sourceChildren, targetChildren,
+                    rscParent.getModifiableChildren(), rtcParent.getModifiableChildren(),
+                    sourceIndex, targetIndex, mapping, unorderedMapping, 
+                    spsmMapping, unorderedSpsmMapping);
         }
 
         sourceIndex.remove(sourceParent.ancestorCount());
         targetIndex.remove(targetParent.ancestorCount());
     }
 
+    protected Map<INode,INode> copyTree(INode from, INode to) {
+        // Copy all source and all target children into the reordered source (rsc)
+        // and reordered target (rtc) contexts (trees), respectively
+        Map<INode,INode> copyMap = new HashMap<>();
+        copyNode(from, to);
+        copyMap.put(from, to);
+        
+        for (INode fromChild : from.getChildren()) {
+            INode toChild = to.createChild();
+            copyMap.putAll(copyTree(fromChild, toChild));
+        }
+        return copyMap;
+    }
+    
+    protected void copyNode(INode from, INode to) {
+        to.nodeData().setName(from.nodeData().getName());
+        to.nodeData().setConcepts(from.nodeData().getConcepts());
+        to.nodeData().setId(from.nodeData().getId());
+        to.nodeData().setIsPreprocessed(from.nodeData().getIsPreprocessed());
+        to.nodeData().setLabelFormula(from.nodeData().getLabelFormula());
+        to.nodeData().setNodeFormula(from.nodeData().getNodeFormula());
+        to.nodeData().setProvenance(from.nodeData().getProvenance());
+        to.nodeData().setSource(from.nodeData().getSource());
+    }
+    
 
     /**
      * Filters the mappings of two siblings node list for which the parents are also supposed to
@@ -159,62 +223,113 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      *
      * @param source           Source list of siblings.
      * @param target           Target list of siblings.
-     * @param semanticRelation a char representing the semantic relation as defined in IMappingElement.
+     * @param rscList          List of source siblings to be reordered.
+     * @param rtcList          List of target siblings to be reordered.
      * @param sourceIndex      list used for reordering of siblings
      * @param targetIndex      list used for reordering of siblings
      * @param mapping          original mapping
+     * @param unorderedMapping        a copy of the original mapping corresponding
+     *                         to the reordered trees
+     * @param spsmMapping      SPSM-filtered ordered mappings are collected here
+     * @param unorderedSpsmMapping  SPSM-filtered unordered mappings are collected here
      */
-    protected void filterMappingsOfSiblingsByRelation(List<INode> source, List<INode> target, char semanticRelation,
-                                                    List<Integer> sourceIndex, List<Integer> targetIndex,
-                                                    IContextMapping<INode> mapping,
-                                                    IContextMapping<INode> spsmMapping) {
+    protected void filterMappingsOfSiblings(List<INode> source, List<INode> target, 
+                                            List<INode> rscList,
+                                            List<INode> rtcList,
+                                            List<Integer> sourceIndex, List<Integer> targetIndex,
+                                            IContextMapping<INode> mapping,
+                                            IContextMapping<INode> unorderedMapping,
+                                            IContextMapping<INode> spsmMapping,
+                                            IContextMapping<INode> unorderedSpsmMapping) {
+        
+        char relationList[] = {IMappingElement.EQUIVALENCE, IMappingElement.MORE_GENERAL,
+                               IMappingElement.LESS_GENERAL};
+        
         int sourceDepth = (source.get(0).ancestorCount() - 1);
         int targetDepth = (target.get(0).ancestorCount() - 1);
 
         int sourceSize = source.size();
         int targetSize = target.size();
 
-        while (sourceIndex.get(sourceDepth) < sourceSize && targetIndex.get(targetDepth) < targetSize) {
-            if (isRelated(source.get(sourceIndex.get(sourceDepth)),
-                    target.get(targetIndex.get(targetDepth)),
-                    semanticRelation, mapping)) {
-
-                //sort the children of the matched node
-                setStrongestMapping(source.get(sourceIndex.get(sourceDepth)),
+        for (char semanticRelation : relationList) {
+            while (sourceIndex.get(sourceDepth) < sourceSize && targetIndex.get(targetDepth) < targetSize) {
+                if (isRelated(source.get(sourceIndex.get(sourceDepth)),
                         target.get(targetIndex.get(targetDepth)),
-                        mapping,
-                        spsmMapping);
-                filterMappingsOfChildren(source.get(sourceIndex.get(sourceDepth)),
-                        target.get(targetIndex.get(targetDepth)),
-                        semanticRelation, sourceIndex, targetIndex, mapping, spsmMapping);
+                        semanticRelation, mapping)) {
 
-                //increment the index
-                inc(sourceIndex, sourceDepth);
-                inc(targetIndex, targetDepth);
-            } else {
-                //look for the next related node in the target
-                int relatedIndex = getRelatedIndex(source, target, semanticRelation,
-                        sourceIndex, targetIndex, mapping, spsmMapping);
-                if (relatedIndex > sourceIndex.get(sourceDepth)) {
-                    //there is a related node, but further between the siblings
-                    //they should be swapped
-                    swapINodes(target, targetIndex.get(targetDepth), relatedIndex);
-
-                    //filter the mappings of the children of the matched node
-                    filterMappingsOfChildren(source.get(sourceIndex.get(sourceDepth)),
+                    setStrongestMapping(source.get(sourceIndex.get(sourceDepth)),
                             target.get(targetIndex.get(targetDepth)),
-                            semanticRelation, sourceIndex, targetIndex, mapping, spsmMapping);
+                            mapping, spsmMapping);
+                    
+                    setStrongestMapping(rscList.get(sourceIndex.get(sourceDepth)),
+                            rtcList.get(targetIndex.get(targetDepth)),
+                            unorderedMapping, unorderedSpsmMapping);
+                    
+                    // Sort the children of the matched node
+                    // TODO: here the assumption is made that mappings only need to be
+                    // verified at the same depth. This is a drastic simplification
+                    // that speeds up the filtering and the subsequent TED algorithm
+                    // but it ignores a lot of mappings.
+                    filterMappingsOfChildren(source.get(sourceIndex.get(sourceDepth)),
+                            target.get(targetIndex.get(targetDepth)), 
+                            rscList.get(sourceIndex.get(sourceDepth)),
+                            rtcList.get(targetIndex.get(targetDepth)),
+                            sourceIndex, targetIndex, 
+                            mapping, unorderedMapping,
+                            spsmMapping, unorderedSpsmMapping);
 
                     //increment the index
                     inc(sourceIndex, sourceDepth);
                     inc(targetIndex, targetDepth);
-
                 } else {
-                    //there is not related item among the remaining siblings
-                    //swap this element of source with the last, and decrement the sourceSize
-                    swapINodes(source, sourceIndex.get(sourceDepth), (sourceSize - 1));
+                    //look for the next related node in the target
+                    int relatedIndex = getRelatedIndex(source, target, 
+                            rscList, rtcList, semanticRelation,
+                            sourceIndex, targetIndex, mapping, unorderedMapping, 
+                            spsmMapping, unorderedSpsmMapping);
+                    if (relatedIndex > sourceIndex.get(sourceDepth)) {
+                        //there is a related node, but further between the siblings
+                        //they should be swapped
+                        swapINodes(target, targetIndex.get(targetDepth), relatedIndex);
+                        swapINodes(rtcList, targetIndex.get(targetDepth), relatedIndex);
 
-                    sourceSize--;
+                        //filter the mappings of the children of the matched node
+                        // TODO: the same assumption is made here as above
+                        filterMappingsOfChildren(source.get(sourceIndex.get(sourceDepth)),
+                                target.get(targetIndex.get(targetDepth)),
+                                rscList.get(targetIndex.get(targetDepth)),
+                                rtcList.get(targetIndex.get(targetDepth)),
+                                sourceIndex, targetIndex, 
+                                mapping, unorderedMapping,
+                                spsmMapping, unorderedSpsmMapping);
+
+                        //increment the index
+                        inc(sourceIndex, sourceDepth);
+                        inc(targetIndex, targetDepth);
+
+                    } else {
+                        //there is no related item among the remaining siblings
+                        //swap this element of source with the last, and decrement the sourceSize
+                        swapINodes(source, sourceIndex.get(sourceDepth), (sourceSize - 1));
+                        swapINodes(rscList, sourceIndex.get(sourceDepth), (sourceSize - 1));
+                        // TODO: here the choice is made to filter out any mappings
+                        // of the children of this node. This means that this SPSM
+                        // implementation adds a constraint on parents needing
+                        // to be mapped in order to consider their children. So if
+                        // the source tree is:
+                        // A
+                        //    B
+                        //       C
+                        // and the target tree is
+                        // B
+                        //    A
+                        //       C
+                        // then, even though SMATCH returns equivalence for the
+                        // second and third levels, SPSM eliminates these matches
+                        // because A and B do not match on the root level.
+                        // It should be reviewed whether this behaviour is intended.
+                        sourceSize--;
+                    }
                 }
             }
         }
@@ -239,29 +354,44 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
      * Looks for the related index for the source list at the position sourceIndex
      * in the target list beginning at the targetIndex position for the defined relation.
      *
-     * @param source      source list of siblings.
-     * @param target      target list of siblings.
+     * @param source      source list of siblings
+     * @param target      target list of siblings
+     * @param rscList     source list of reordered siblings
+     * @param rtcList     target list of reordered siblings
      * @param relation    relation
      * @param sourceIndex list used for reordering of siblings
      * @param targetIndex list used for reordering of siblings
+     * @param mapping          original mapping
+     * @param unorderedMapping        a copy of the original mapping corresponding
+     *                         to the reordered trees
+     * @param spsmMapping      SPSM-filtered ordered mappings are collected here
+     * @param unorderedSpsmMapping  SPSM-filtered unordered mappings are collected here
      * @return the index of the related element in target, or -1 if there is no relate element.
      */
-    protected int getRelatedIndex(List<INode> source, List<INode> target, char relation,
+    protected int getRelatedIndex(List<INode> source, List<INode> target, 
+                                List<INode> rscList, List<INode> rtcList,
+                                char relation,
                                 List<Integer> sourceIndex, List<Integer> targetIndex,
                                 IContextMapping<INode> mapping,
-                                IContextMapping<INode> spsmMapping) {
+                                IContextMapping<INode> unorderedMapping,
+                                IContextMapping<INode> spsmMapping,
+                                IContextMapping<INode> unorderedSpsmMapping) {
         int srcIndex = sourceIndex.get(source.get(0).ancestorCount() - 1);
         int tgtIndex = targetIndex.get(target.get(0).ancestorCount() - 1);
 
         int returnIndex = -1;
 
         INode sourceNode = source.get(srcIndex);
+        INode rsNode = rscList.get(srcIndex);
 
         //find the first one who is related in the same level
         for (int i = tgtIndex + 1; i < target.size(); i++) {
             INode targetNode = target.get(i);
+            INode rtNode = rtcList.get(i);
             if (isRelated(sourceNode, targetNode, relation, mapping)) {
                 setStrongestMapping(sourceNode, targetNode, mapping, spsmMapping);
+                setStrongestMapping(rsNode, rtNode, unorderedMapping, unorderedSpsmMapping);
+                
                 return i;
             }
         }
@@ -269,6 +399,8 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
         //there was no correspondence between siblings in source and target lists
         //try to clean the mapping elements
         computeStrongestMappingForSource(source.get(srcIndex), mapping, spsmMapping);
+        computeStrongestMappingForSource(rscList.get(srcIndex), unorderedMapping, 
+                unorderedSpsmMapping);
 
         return returnIndex;
     }
@@ -315,7 +447,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
             for (Iterator<INode> targetNodes = mapping.getTargetContext().nodeIterator(); targetNodes.hasNext(); ) {
                 INode node = targetNodes.next();
                 //if its not the target of the mapping elements and the relation is weaker
-                if (source != node && mapping.getRelation(source, node) != IMappingElement.IDK
+                if (target != node && mapping.getRelation(source, node) != IMappingElement.IDK
                         && isPrecedent(mapping.getRelation(source, target), mapping.getRelation(source, node))) {
                     mapping.setRelation(source, node, IMappingElement.IDK);
                 }
@@ -324,7 +456,7 @@ public class SPSMMappingFilter extends BaseFilter implements IMappingFilter, IAs
             //deletes all the less precedent relations for the same target node
             for (Iterator<INode> sourceNodes = mapping.getSourceContext().nodeIterator(); sourceNodes.hasNext(); ) {
                 INode node = sourceNodes.next();
-                if (target != node) {
+                if (source != node) {
                     mapping.setRelation(node, target, IMappingElement.IDK);
                 }
             }


### PR DESCRIPTION
Fix by @gbella: Modified the tree edit distance algorithm to compute *unordered* TED

The previous SPSM version implemented an ordered tree edit distance algorithm which did not consider the two trees A(B,C) and A(C,B) as identical (where B and C are siblings and children of A). As the most typical use case of SPSM is matching of function signatures, unordered TED (where the order of the arguments does not make a difference) is a more suitable solution. The new SPSM version thus implements unordered TED. Note that, while unordered TED in its generality is NP-complete, the implementation within SPSM is still polynomial because of preexisting simplifications in the underlying TED algorithm (substitution operations can only be done on the same level, deletion and insertion are only possible on leaves).